### PR TITLE
udpate FBAudienceNetwork a 6.15.2

### DIFF
--- a/ios/facebook_app_events.podspec
+++ b/ios/facebook_app_events.podspec
@@ -22,5 +22,5 @@ Flutter plugin for Facebook Analytics and App Events
   
   # See docs on FBAudienceNetwork
   # https://developers.facebook.com/docs/audience-network/setting-up/platform-setup/ios/add-sdk/
-  s.dependency 'FBAudienceNetwork', '~> 6.14'
+  s.dependency 'FBAudienceNetwork', '6.15.2'
 end


### PR DESCRIPTION
https://developers.facebook.com/docs/audience-network/setting-up/platform-setup/ios/changelog/

La ultima version (6.16) causa conflictos al momento de compilar. se setea la version 6.15.2